### PR TITLE
Adicionado suporte para informações detalhadas de pacotes do PyPI

### DIFF
--- a/cli/app.py
+++ b/cli/app.py
@@ -19,13 +19,14 @@ def license_metadata(classifiers: list[str]) -> str:
 
 def last_release(releases: dict[str, Any]) -> dict[str, str]:
     release = sorted(releases, key=Version)[-1]
-
-    return {'relase': release, 'date': releases[release][0]['upload_time']}
+    return {
+        'relase': release, 
+        'date': releases[release][0]['upload_time']
+    }
 
 
 def first_release(releases: dict[str, Any]) -> dict[str, str]:
     release = sorted(releases, key=Version)[0]
-
     try:
         return {
             'release': release,
@@ -38,7 +39,6 @@ def first_release(releases: dict[str, Any]) -> dict[str, str]:
 @app.command()
 def package_data(package: str):
     response = get(BASE_URL.format(package=package), timeout=None)
-
     data = response.json()
 
     license = license_metadata(data['info']['classifiers'])
@@ -55,3 +55,49 @@ def package_data(package: str):
             'release_atual': l_release,
         }
     )
+    
+
+@app.command()
+def total_versions(package: str):
+    response = get(BASE_URL.format(package=package), timeout=None)
+    data = response.json()
+    total = len(data['releases'].keys())
+    print(f"Total de versões disponíveis para o pacote {package}: {total}")
+
+
+@app.command()
+def package_versions(package: str):
+    response = get(BASE_URL.format(package=package), timeout=None)
+    data = response.json()
+    print(f"Versões disponíveis para o pacote {package}:")
+    print(list(data['releases'].keys()))
+
+
+@app.command()
+def total_downloads(package: str):
+    response = get(BASE_URL.format(package=package), timeout=None)
+    data = response.json()
+    download_counts = [
+        release['downloads'] 
+        for release in data['releases'].values() 
+        if 'downloads' in release
+    ]
+    
+    print(
+        "Total de downloads para o pacote {package}: {total}".format(
+            package=package, total=sum(download_counts)
+        )
+    )
+
+
+@app.command()
+def package_info(package: str):
+    response = get(BASE_URL.format(package=package), timeout=None)
+    data = response.json()
+    print(
+        {
+            'package': package,
+            'info': data['info']
+        }
+    )
+


### PR DESCRIPTION
Adicionado novas funcionalidades ao código existente para obter informações de pacotes no **PyPI**. As seguintes funcionalidades foram implementadas:

## Recursos
Comando **total_versions:** Adicionado um novo comando **total_versions** que recupera o número total de versões disponíveis para um determinado pacote. Este comando faz uma requisição HTTP ao **PyPI** e conta o número de releases na resposta.

Comando **package_versions**: Adicionado um novo comando **package_versions** que recupera e imprime todas as versões disponíveis para um determinado pacote. Este comando também faz uma requisição HTTP ao PyPI e extrai as versões de release da resposta.

Comando **total_downloads**: Adicionado um novo comando **total_downloads** que recupera o número total de downloads para um determinado pacote. Este comando faz uma requisição HTTP ao **PyPI**, extrai as contagens de downloads de cada release e calcula a soma de todas as contagens.

Comando **package_info**: Adicionado um novo comando **package_info** que recupera e imprime informações detalhadas sobre um determinado pacote. Este comando busca as informações do pacote no **PyPI** e inclui informações gerais e metadados do pacote.

## Exemplo
```

@app.command()
def package_versions(package: str):
    data = send_request(package)
    print(f"Versões disponíveis para o pacote {package}:")
    print(list(data['releases'].keys()))
    
    # # output
    Versões disponíveis para o pacote requests:
    [
        '0.0.1',
        '0.10.0',
        '0.10.1',
        ...
    ]

```